### PR TITLE
allow using wgpu_backends

### DIFF
--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -16,7 +16,7 @@ pub struct GpuCtx {
 
 impl GpuCtx {
     pub fn new(config: &GraphicsConfig) -> Self {
-        let instance = Instance::new(&wgpu::InstanceDescriptor::default());
+        let instance = Instance::new(&wgpu::InstanceDescriptor::from_env_or_default());
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: config.power_preference,


### PR DESCRIPTION
For some reason wgpu is defaulting to gl for me which breaks vibe, this will at least allow the user to use WGPU_BACKENDS=vulkan

there is a good reason for letting this be configurable as different hardware has differing levels of support