### PR TITLE
add option to select default backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,26 @@ sudo apt install librust-wayland-client-dev librust-alsa-sys-dev libxkbcommon-de
 4. Your microphone is very likely be catched as the audio source.
    To fix that open up `pavucontrol` and set the audio source (see: https://github.com/TornaxO7/shady?tab=readme-ov-file#shady-audio-doesnt-listen-to-my-systems-audio)
 
-# Output config file format
+# Configs
+
+## General config file
+
+`~/.config/vibe-daemon/config.toml` contains the config `vibe-daemon` itself and has the following options:
+
+```toml
+[graphics_config]
+# Decide which gpu vibe should prefer.
+# Can be either "low-power" (often your integrated GPU) or "high-performance" (your external GPU)
+power_preference = "low-power"
+
+# Set backend which you'd like to use. Can be any of those entries with `pub const <NAME>`: https://docs.rs/wgpu/latest/wgpu/struct.Backends.html#implementations
+# Note:
+#  - It's recommended to let it be `VULKAN`
+#  - Writing each letter CAPITALIZED is required!
+backend = "VULKAN"
+```
+
+## Output config file format
 
 If you'd like to tweak around:
 The config for each output can be seen in `~/.config/vibe-daemon/output_configs/<output-name>.toml`.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,11 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Subcommand, Debug)]
+pub enum Command {}
+
+#[derive(Parser, Debug)]
+pub struct Args {
+    /// The subcommand which should be executed
+    #[command(subcommand)]
+    pub command: Option<Command>,
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,7 @@
-use serde::{Deserialize, Serialize};
 use std::io;
+
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
 
 use crate::gpu::GraphicsConfig;
 
@@ -17,7 +19,7 @@ impl Config {
     }
 }
 
-pub fn load() -> io::Result<Config> {
+pub fn load() -> anyhow::Result<Config> {
     let content = std::fs::read_to_string(vibe_daemon::get_config_path())?;
-    Ok(toml::from_str(&content).unwrap())
+    toml::from_str(&content).context("Your config file is invalid!")
 }

--- a/src/gpu/config.rs
+++ b/src/gpu/config.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use wgpu::PowerPreference;
+use wgpu::{Backends, PowerPreference};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GraphicsConfig {
@@ -8,12 +8,16 @@ pub struct GraphicsConfig {
     /// See <https://docs.rs/wgpu/latest/wgpu/enum.PowerPreference.html#variants>
     /// for the available options
     pub power_preference: PowerPreference,
+
+    /// Set the backend which should be used.
+    pub backend: Backends,
 }
 
 impl Default for GraphicsConfig {
     fn default() -> Self {
         Self {
             power_preference: PowerPreference::LowPower,
+            backend: Backends::VULKAN,
         }
     }
 }

--- a/src/gpu/mod.rs
+++ b/src/gpu/mod.rs
@@ -16,7 +16,14 @@ pub struct GpuCtx {
 
 impl GpuCtx {
     pub fn new(config: &GraphicsConfig) -> Self {
-        let instance = Instance::new(&wgpu::InstanceDescriptor::from_env_or_default());
+        let instance = Instance::new(
+            &wgpu::InstanceDescriptor {
+                backends: config.backend,
+                ..Default::default()
+            }
+            .with_env(),
+        );
+
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: config.power_preference,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,6 @@ mod state;
 use std::num::NonZeroUsize;
 
 use state::State;
-use tracing::{debug, info};
 use tracing_subscriber::EnvFilter;
 use wayland_client::{globals::registry_queue_init, Connection};
 
@@ -19,7 +18,7 @@ fn main() -> anyhow::Result<()> {
         let conn = Connection::connect_to_env()?;
         let (globals, event_loop) = registry_queue_init(&conn)?;
         let qh = event_loop.handle();
-        let state = State::new(&globals, &qh);
+        let state = State::new(&globals, &qh)?;
 
         (state, event_loop)
     };
@@ -40,7 +39,4 @@ fn init_logging() {
         .without_time()
         .pretty()
         .init();
-
-    debug!("Debug logger initialised");
-    info!("Info logger initialised");
 }


### PR DESCRIPTION
Follow-Up PR for https://github.com/TornaxO7/vibe/pull/17

- adds an option for `vibe` to select the backend (default is vulkan)
- `vibe` also backups your config file if it's invalid and creates a new default one.