### PR TITLE
kde: workaround regarding desktop interactivity

### DIFF
--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -7,6 +7,7 @@ use raw_window_handle::{
     RawDisplayHandle, RawWindowHandle, WaylandDisplayHandle, WaylandWindowHandle,
 };
 use smithay_client_toolkit::{
+    compositor::{CompositorState, Region},
     output::OutputInfo,
     shell::{
         wlr_layer::{Anchor, KeyboardInteractivity, LayerSurface},
@@ -55,6 +56,7 @@ impl OutputCtx {
     pub fn new(
         name: &str,
         conn: &Connection,
+        comp: &CompositorState,
         info: OutputInfo,
         layer_surface: LayerSurface,
         gpu: &GpuCtx,
@@ -62,8 +64,12 @@ impl OutputCtx {
     ) -> anyhow::Result<Self> {
         let size = Size::from(&info);
 
-        layer_surface.set_exclusive_zone(-69); // nice! (arbitrary chosen :P hehe)
-        layer_surface.set_anchor(Anchor::BOTTOM);
+        {
+            let region = Region::new(comp).unwrap();
+            layer_surface.set_input_region(Some(region.wl_region()));
+        }
+        layer_surface.set_exclusive_zone(-1); // nice! (arbitrary chosen :P hehe)
+        layer_surface.set_anchor(Anchor::all());
         layer_surface.set_size(size.width, size.height);
         layer_surface.set_keyboard_interactivity(KeyboardInteractivity::None);
         layer_surface.commit();

--- a/src/state.rs
+++ b/src/state.rs
@@ -160,7 +160,15 @@ impl OutputHandler for State {
             )
         };
 
-        let ctx = match OutputCtx::new(&name, conn, info, layer_surface, &self.gpu, config) {
+        let ctx = match OutputCtx::new(
+            &name,
+            conn,
+            &self.compositor_state,
+            info,
+            layer_surface,
+            &self.gpu,
+            config,
+        ) {
             Ok(ctx) => ctx,
             Err(err) => {
                 error!("Skipping output '{}' because {:?}", name, err);


### PR DESCRIPTION
layer shells seem be behave similar to windows.
This allows the user to use interact with the desktop again, however there's a "bring-to-front" functionality.
Maybe we can improve this somehow but I think that this is rather a "bug"(?) from Kwin.

Closes https://github.com/TornaxO7/vibe/issues/28