### PR TITLE
fix: remove gamma correction requirement for shaders

### DIFF
--- a/vibe-renderer/examples/aurodio.rs
+++ b/vibe-renderer/examples/aurodio.rs
@@ -35,7 +35,7 @@ impl<'a> State<'a> {
         let surface_config = {
             let capabilities = surface.get_capabilities(renderer.adapter());
 
-            let format = capabilities.formats.iter().find(|f| f.is_srgb()).unwrap();
+            let format = capabilities.formats.iter().find(|f| !f.is_srgb()).unwrap();
 
             wgpu::SurfaceConfiguration {
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT,

--- a/vibe-renderer/examples/bars_with_color_variant.rs
+++ b/vibe-renderer/examples/bars_with_color_variant.rs
@@ -35,7 +35,7 @@ impl<'a> State<'a> {
         let surface_config = {
             let capabilities = surface.get_capabilities(renderer.adapter());
 
-            let format = capabilities.formats.iter().find(|f| f.is_srgb()).unwrap();
+            let format = capabilities.formats.iter().find(|f| !f.is_srgb()).unwrap();
 
             wgpu::SurfaceConfiguration {
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT,

--- a/vibe-renderer/examples/bars_with_fragment_code_variant.rs
+++ b/vibe-renderer/examples/bars_with_fragment_code_variant.rs
@@ -35,7 +35,7 @@ impl<'a> State<'a> {
         let surface_config = {
             let capabilities = surface.get_capabilities(renderer.adapter());
 
-            let format = capabilities.formats.iter().find(|f| f.is_srgb()).unwrap();
+            let format = capabilities.formats.iter().find(|f| !f.is_srgb()).unwrap();
 
             wgpu::SurfaceConfiguration {
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
@@ -67,13 +67,7 @@ impl<'a> State<'a> {
                             uv.y = 1. - uv.y;
                             uv.x *= iResolution.x / iResolution.y;
 
-                            var col = sin(vec3(2., 4., 8.) * iTime * .25) * .2 + .6;
-
-                            const GAMMA: f32 = 2.2;
-                            col.r = pow(col.r, GAMMA);
-                            col.g = pow(col.g, GAMMA);
-                            col.b = pow(col.b, GAMMA);
-
+                            let col: vec3<f32> = sin(vec3(2., 4., 8.) * iTime * .25) * .2 + .6;
                             return vec4<f32>(col, uv.y);
                         }
                         "

--- a/vibe-renderer/examples/bars_with_presence_gradient_variant.rs
+++ b/vibe-renderer/examples/bars_with_presence_gradient_variant.rs
@@ -38,7 +38,7 @@ impl<'a> State<'a> {
         let surface_config = {
             let capabilities = surface.get_capabilities(renderer.adapter());
 
-            let format = capabilities.formats.iter().find(|f| f.is_srgb()).unwrap();
+            let format = capabilities.formats.iter().find(|f| !f.is_srgb()).unwrap();
 
             wgpu::SurfaceConfiguration {
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT,

--- a/vibe-renderer/examples/fragment_canvas.rs
+++ b/vibe-renderer/examples/fragment_canvas.rs
@@ -35,7 +35,7 @@ impl<'a> State<'a> {
         let surface_config = {
             let capabilities = surface.get_capabilities(renderer.adapter());
 
-            let format = capabilities.formats.iter().find(|f| f.is_srgb()).unwrap();
+            let format = capabilities.formats.iter().find(|f| !f.is_srgb()).unwrap();
 
             wgpu::SurfaceConfiguration {
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT,

--- a/vibe-renderer/examples/value_noise.rs
+++ b/vibe-renderer/examples/value_noise.rs
@@ -32,7 +32,7 @@ impl<'a> State<'a> {
         let surface_config = {
             let capabilities = surface.get_capabilities(renderer.adapter());
 
-            let format = capabilities.formats.iter().find(|f| f.is_srgb()).unwrap();
+            let format = capabilities.formats.iter().find(|f| !f.is_srgb()).unwrap();
 
             wgpu::SurfaceConfiguration {
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT,

--- a/vibe-renderer/src/components/aurodio/shaders/fragment_shader.wgsl
+++ b/vibe-renderer/src/components/aurodio/shaders/fragment_shader.wgsl
@@ -106,10 +106,5 @@ fn main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
 
     col += dust_layer(uv, base_color2);
     col = clamp(col, vec4<f32>(0.), vec4<f32>(1.));
-    
-    const GAMMA: f32 = 2.2;
-    col.r = pow(col.r, GAMMA);
-    col.g = pow(col.g, GAMMA);
-    col.b = pow(col.b, GAMMA);
     return col;
 }

--- a/vibe/src/output/config/component.rs
+++ b/vibe/src/output/config/component.rs
@@ -15,14 +15,10 @@ const GAMMA: f32 = 2.2;
 const DEFAULT_BARS_WGSL_FRAGMENT_CODE: &str = "
 @fragment
 fn main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
-    var color = sin(vec3<f32>(2., 4., 8.) * iTime * .25) * .2 + .6;
+    let color: vec3<f32> = sin(vec3<f32>(2., 4., 8.) * iTime * .25) * .2 + .6;
+    let alpha = 1. - pos.y / iResolution.y);
 
-    // apply gamma correction
-    const GAMMA: f32 = 2.2;
-    color.r = pow(color.r, GAMMA);
-    color.g = pow(color.g, GAMMA);
-    color.b = pow(color.b, GAMMA);
-    return vec4<f32>(color, 1. - pos.y / iResolution.y);
+    return vec4<f32>(color, alpha);
 }
 ";
 
@@ -72,13 +68,13 @@ impl ComponentConfig {
                 variant,
             } => {
                 let variant = match variant {
-                    BarVariantConfig::Color(rgba) => BarVariant::Color(rgba.gamma_corrected()),
+                    BarVariantConfig::Color(rgba) => BarVariant::Color(rgba.as_f32()),
                     BarVariantConfig::PresenceGradient {
                         high_presence,
                         low_presence,
                     } => BarVariant::PresenceGradient {
-                        high: high_presence.gamma_corrected(),
-                        low: low_presence.gamma_corrected(),
+                        high: high_presence.as_f32(),
+                        low: low_presence.as_f32(),
                     },
                     BarVariantConfig::FragmentCode(code) => BarVariant::FragmentCode(code.clone()),
                 };
@@ -137,7 +133,7 @@ impl ComponentConfig {
 pub struct Rgba(pub [u8; 4]);
 
 impl Rgba {
-    pub fn gamma_corrected(&self) -> [f32; 4] {
+    pub fn as_f32(&self) -> [f32; 4] {
         let mut rgba_f32 = [0f32; 4];
         for (idx, value) in self.0.iter().enumerate() {
             rgba_f32[idx] = (*value as f32) / 255f32;

--- a/vibe/src/output/mod.rs
+++ b/vibe/src/output/mod.rs
@@ -122,7 +122,7 @@ pub fn get_surface_config(
     let format = surface_caps
         .formats
         .iter()
-        .find(|f| f.is_srgb())
+        .find(|f| !f.is_srgb())
         .copied()
         .unwrap();
 


### PR DESCRIPTION
Setting the output format to non-srgb allows shaders to be written without applying the gamma correction inside the code. Just set the color as a float and you are done!