### PR TITLE
feature(graph): add smoothness option

### DIFF
--- a/vibe-renderer/examples/graph_with_color_variant.rs
+++ b/vibe-renderer/examples/graph_with_color_variant.rs
@@ -61,6 +61,7 @@ impl<'a> State<'a> {
             output_texture_format: surface_config.format,
             variant: GraphVariant::Color([0., 0., 1., 1.]),
             max_height: 0.5,
+            smoothness: 0.01,
         });
 
         Self {

--- a/vibe-renderer/examples/graph_with_horizontal_gradient.rs
+++ b/vibe-renderer/examples/graph_with_horizontal_gradient.rs
@@ -64,6 +64,7 @@ impl<'a> State<'a> {
                 right: [0., 0., 1., 1.],
             },
             max_height: 0.5,
+            smoothness: 0.01,
         });
 
         Self {

--- a/vibe-renderer/examples/graph_with_vertical_gradient.rs
+++ b/vibe-renderer/examples/graph_with_vertical_gradient.rs
@@ -65,6 +65,7 @@ impl<'a> State<'a> {
                 bottom: [0.008, 0.435, 0.447, 1.],
             },
             max_height: 0.5,
+            smoothness: 0.1,
         });
 
         Self {

--- a/vibe-renderer/src/components/graph/fragment_color.wgsl
+++ b/vibe-renderer/src/components/graph/fragment_color.wgsl
@@ -7,6 +7,9 @@ var<uniform> max_height: f32;
 @group(0) @binding(2)
 var<uniform> color: vec4f;
 
+@group(0) @binding(8)
+var<uniform> smoothness: f32;
+
 @group(1) @binding(0)
 var<storage, read> freqs: array<f32>;
 
@@ -15,7 +18,7 @@ fn main(@builtin(position) pos: vec4f) -> @location(0) vec4f {
     let bar_height = freqs[u32(pos.x)];
 
     let relative_y = 1. - pos.y / canvas_height;
-    let presence = step(relative_y, bar_height * max_height);
+    let presence = smoothstep(relative_y - smoothness, relative_y, bar_height * max_height);
 
     return color * presence;
 }

--- a/vibe-renderer/src/components/graph/fragment_horizontal_gradient.wgsl
+++ b/vibe-renderer/src/components/graph/fragment_horizontal_gradient.wgsl
@@ -13,6 +13,9 @@ var<uniform> color_right: vec4f;
 @group(0) @binding(5)
 var<uniform> canvas_width: f32;
 
+@group(0) @binding(8)
+var<uniform> smoothness: f32;
+
 @group(1) @binding(0)
 var<storage, read> freqs: array<f32>;
 
@@ -22,7 +25,7 @@ fn main(@builtin(position) pos: vec4f) -> @location(0) vec4f {
 
     let relative_y = 1. - pos.y / canvas_height;
     let relative_x = pos.x / canvas_width;
-    let presence = step(relative_y, bar_height * max_height);
+    let presence = smoothstep(relative_y - smoothness, relative_y, bar_height * max_height);
 
     return mix(color_left, color_right, relative_x) * presence;
 }

--- a/vibe-renderer/src/components/graph/fragment_vertical_gradient.wgsl
+++ b/vibe-renderer/src/components/graph/fragment_vertical_gradient.wgsl
@@ -10,6 +10,9 @@ var<uniform> color_top: vec4f;
 @group(0) @binding(7)
 var<uniform> color_bottom: vec4f;
 
+@group(0) @binding(8)
+var<uniform> smoothness: f32;
+
 @group(1) @binding(0)
 var<storage, read> freqs: array<f32>;
 
@@ -17,9 +20,9 @@ var<storage, read> freqs: array<f32>;
 fn main(@builtin(position) pos: vec4f) -> @location(0) vec4f {
     let bar_height = freqs[u32(pos.x)];
 
-    let relative_canvas_height = 1. - pos.y / canvas_height;
-    let presence = step(relative_canvas_height, bar_height * max_height);
-    let relative_graph_height = relative_canvas_height / (bar_height * max_height);
+    let relative_y = 1. - pos.y / canvas_height;
+    let presence = smoothstep(relative_y - smoothness, relative_y, bar_height * max_height);
+    let relative_graph_height = relative_y / (bar_height * max_height);
 
     return mix(color_bottom, color_top, relative_graph_height) * presence;
 }

--- a/vibe-renderer/src/components/graph/mod.rs
+++ b/vibe-renderer/src/components/graph/mod.rs
@@ -32,6 +32,7 @@ enum Binding0 {
     CanvasWidth = 5,
     VerticalGradientTop = 6,
     VerticalGradientBottom = 7,
+    Smoothness = 8,
 }
 
 #[repr(u32)]
@@ -48,6 +49,7 @@ pub struct GraphDescriptor<'a> {
 
     pub variant: GraphVariant,
     pub max_height: f32,
+    pub smoothness: f32,
 }
 
 pub struct Graph {
@@ -90,6 +92,16 @@ impl Graph {
             device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
                 label: Some("Graph: `max_height` buffer"),
                 contents: bytemuck::bytes_of(&desc.max_height),
+                usage: wgpu::BufferUsages::UNIFORM,
+            }),
+        );
+
+        bind_group0.insert_buffer(
+            Binding0::Smoothness as u32,
+            wgpu::ShaderStages::FRAGMENT,
+            device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("Graph: `smoothness` buffer"),
+                contents: bytemuck::bytes_of(&desc.smoothness),
                 usage: wgpu::BufferUsages::UNIFORM,
             }),
         );

--- a/vibe-renderer/tests/graph_color_variant/mod.rs
+++ b/vibe-renderer/tests/graph_color_variant/mod.rs
@@ -15,6 +15,7 @@ fn test() {
         output_texture_format: tester.output_texture_format(),
         max_height: 1.,
         variant: GraphVariant::Color(RED),
+        smoothness: 0.01,
     });
 
     let _img = tester.render(graph);

--- a/vibe-renderer/tests/graph_horizontal_gradient_variant/mod.rs
+++ b/vibe-renderer/tests/graph_horizontal_gradient_variant/mod.rs
@@ -21,6 +21,7 @@ fn test() {
             left: RED,
             right: BLUE,
         },
+        smoothness: 0.01,
     });
 
     let _img = tester.render(graph);

--- a/vibe-renderer/tests/graph_vertical_gradient_variant/mod.rs
+++ b/vibe-renderer/tests/graph_vertical_gradient_variant/mod.rs
@@ -21,6 +21,7 @@ fn test() {
             top: BLUE,
             bottom: RED,
         },
+        smoothness: 0.01,
     });
 
     let _img = tester.render(graph);

--- a/vibe/src/output/config/component.rs
+++ b/vibe/src/output/config/component.rs
@@ -35,6 +35,7 @@ pub enum ComponentConfig {
         audio_conf: GraphAudioConfig,
         max_height: f32,
         variant: GraphVariantConfig,
+        smoothness: f32,
     },
     Circle {
         audio_conf: BarAudioConfig,
@@ -138,6 +139,7 @@ impl ComponentConfig {
                 audio_conf,
                 max_height,
                 variant,
+                smoothness,
             } => {
                 let variant = match variant {
                     GraphVariantConfig::Color(rgba) => GraphVariant::Color(rgba.as_f32()),
@@ -162,6 +164,7 @@ impl ComponentConfig {
                     output_texture_format: texture_format,
                     variant,
                     max_height: *max_height,
+                    smoothness: *smoothness,
                 })) as Box<dyn Component>)
             }
             ComponentConfig::Circle {


### PR DESCRIPTION
Let's the user be able to smooth out the edge of the graph so alias artifacts are less likely to appear.