### PR TITLE
feat(window): let window title include output name

### DIFF
--- a/vibe/src/window.rs
+++ b/vibe/src/window.rs
@@ -247,7 +247,10 @@ impl OutputRenderer<'_> {
 impl ApplicationHandler for OutputRenderer<'_> {
     fn resumed(&mut self, event_loop: &winit::event_loop::ActiveEventLoop) {
         let window = event_loop
-            .create_window(winit::window::WindowAttributes::default())
+            .create_window(
+                winit::window::WindowAttributes::default()
+                    .with_title(format!("vibe - {}", &self.output_name)),
+            )
             .expect("Create window");
 
         self.state = Some(State::new(window, &self.renderer));


### PR DESCRIPTION
This is just a little quality-of-life improvement: Instead of using the default window title of the hot-reloading window, `vibe` will display the output name.

Before this PR:
![image](https://github.com/user-attachments/assets/8bc84b5e-497b-4e5f-9805-5386f1262174)

After this PR:
![image](https://github.com/user-attachments/assets/ee2d254f-d682-4bc6-bca0-632266ab369f)
