### PR TITLE
feat(radial): add `height-gradient-variant`

### DIFF
--- a/vibe-renderer/examples/demo/cli.rs
+++ b/vibe-renderer/examples/demo/cli.rs
@@ -17,6 +17,7 @@ pub enum ComponentName {
     GraphVerticalGradientVariant,
 
     RadialColorVariant,
+    RadialHeightGradientVariant,
 
     ChessyBoxVariant,
 

--- a/vibe-renderer/examples/demo/main.rs
+++ b/vibe-renderer/examples/demo/main.rs
@@ -278,6 +278,30 @@ impl<'a> State<'a> {
                 bar_width: 0.015,
                 position: (0.5, 0.5),
             })) as Box<dyn Component>),
+
+            ComponentName::RadialHeightGradientVariant => {
+                Ok(Box::new(Radial::new(&RadialDescriptor {
+                    device: renderer.device(),
+                    processor,
+                    audio_conf: vibe_audio::BarProcessorConfig {
+                        amount_bars: NonZero::new(60).unwrap(),
+                        sensitivity: 4.0,
+                        ..Default::default()
+                    },
+                    output_texture_format: surface_config.format,
+
+                    variant: RadialVariant::HeightGradient {
+                        inner: [1., 0., 0., 1.],
+                        outer: [1., 1., 1., 1.],
+                    },
+
+                    init_rotation: cgmath::Deg(90.),
+                    circle_radius: 0.3,
+                    bar_height_sensitivity: 1.,
+                    bar_width: 0.02,
+                    position: (0.5, 0.5),
+                })) as Box<dyn Component>)
+            }
             ComponentName::ChessyBoxVariant => Ok(Box::new(Chessy::new(&ChessyDescriptor {
                 renderer: &renderer,
                 sample_processor: processor,

--- a/vibe-renderer/src/components/radial/descriptor.rs
+++ b/vibe-renderer/src/components/radial/descriptor.rs
@@ -21,4 +21,5 @@ pub struct RadialDescriptor<'a, F: Fetcher> {
 
 pub enum RadialVariant {
     Color(Rgba),
+    HeightGradient { inner: Rgba, outer: Rgba },
 }

--- a/vibe-renderer/src/components/radial/shaders/fragment_color.wgsl
+++ b/vibe-renderer/src/components/radial/shaders/fragment_color.wgsl
@@ -1,0 +1,11 @@
+@fragment
+fn fragment_main(in: Output) -> @location(0) vec4f {
+    let max_width = bar_width / 2.;
+    let rel_y = abs(in.y) / max_width;
+
+    let width_smoothing = smoothstep(1., 0., rel_y);
+
+    // smooth out the line at the edge of the inner circle
+    let bottom_smoothing = smoothstep(.0, .01, in.x);
+    return color * width_smoothing * bottom_smoothing;
+}

--- a/vibe-renderer/tests/mod.rs
+++ b/vibe-renderer/tests/mod.rs
@@ -16,11 +16,13 @@ mod graph_vertical_gradient_variant;
 mod circle_graph;
 
 mod radial_with_color_variant;
+mod radial_with_height_gradient_variant;
 
 const PIXEL_SIZE: u32 = std::mem::size_of::<u32>() as u32;
 
 // some colors
 const RED: [f32; 4] = [1., 0., 0., 1.];
+const WHITE: [f32; 4] = [1f32; 4];
 
 pub struct Tester<'a> {
     pub output_width: u32,

--- a/vibe-renderer/tests/radial_with_height_gradient_variant/mod.rs
+++ b/vibe-renderer/tests/radial_with_height_gradient_variant/mod.rs
@@ -1,0 +1,32 @@
+use vibe_audio::{fetcher::DummyFetcher, BarProcessorConfig, SampleProcessor};
+use vibe_renderer::components::{Radial, RadialDescriptor, RadialVariant};
+
+use crate::Tester;
+
+#[test]
+fn test() {
+    let mut tester = Tester::default();
+
+    let sample_processor = SampleProcessor::new(DummyFetcher::new(2));
+    let radial = Radial::new(&RadialDescriptor {
+        device: tester.renderer.device(),
+        processor: &sample_processor,
+        audio_conf: BarProcessorConfig::default(),
+        output_texture_format: tester.output_texture_format(),
+        variant: RadialVariant::HeightGradient {
+            inner: super::RED,
+            outer: super::WHITE,
+        },
+
+        init_rotation: cgmath::Deg(90.0),
+        circle_radius: 0.01,
+        bar_height_sensitivity: 0.3,
+        bar_width: 0.1,
+        position: (0.5, 0.5),
+    });
+
+    let _img = tester.render(radial);
+
+    // we don't do anything else because all bars are at the bottom
+    // but the fragment shader should work... trust me bro
+}

--- a/vibe/src/output/config/component/mod.rs
+++ b/vibe/src/output/config/component/mod.rs
@@ -231,6 +231,12 @@ impl ComponentConfig {
             } => {
                 let variant = match variant {
                     RadialVariantConfig::Color(rgba) => RadialVariant::Color(rgba.as_f32()),
+                    RadialVariantConfig::HeightGradient { inner, outer } => {
+                        RadialVariant::HeightGradient {
+                            inner: inner.as_f32(),
+                            outer: outer.as_f32(),
+                        }
+                    }
                 };
 
                 Ok(Box::new(Radial::new(&RadialDescriptor {

--- a/vibe/src/output/config/component/radial.rs
+++ b/vibe/src/output/config/component/radial.rs
@@ -32,4 +32,5 @@ impl From<&RadialAudioConfig> for vibe_audio::BarProcessorConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum RadialVariantConfig {
     Color(Rgba),
+    HeightGradient { inner: Rgba, outer: Rgba },
 }

--- a/vibe/src/output/config/reference-config.toml
+++ b/vibe/src/output/config/reference-config.toml
@@ -258,6 +258,22 @@ freq_range = { start = 50, end = 10000 }
 [components.Radial.variant]
 Color = [0, 255, 0, 255]
 
+## Radial - HeightGradientVariant
+[[components]]
+[components.Radial]
+init_rotation = 90.0
+circle_radius = 0.2
+bar_height_sensitivity = 1.0
+bar_width = 0.01
+position = [0.5, 0.5]
+[components.Radial.audio_conf]
+amount_bars = 60
+sensitivity = 5.0
+freq_range = { start = 50, end = 10000 }
+[components.Radial.variant.HeightGradient]
+inner = [255, 0, 0, 255]
+outer = [255, 255, 255, 255]
+
 # Chessy
 
 ## Chessy - Box


### PR DESCRIPTION
<img width="945" height="1024" alt="image" src="https://github.com/user-attachments/assets/ce4cb460-c4cb-4c3e-80c0-cc11b01fdba0" />

With that variant you can set two colors for the radial: The color for the inner part of the circle and another color at the outer part of the circle.

Makes the `radial` component probably more interesting :)