### PR TITLE
fix(kde): don't remove visualizer if interacting with desktop

### DIFF
--- a/vibe/src/output/mod.rs
+++ b/vibe/src/output/mod.rs
@@ -39,7 +39,7 @@ impl OutputCtx {
     ) -> Self {
         let size = Size::from(&info);
 
-        layer_surface.set_exclusive_zone(-1); // nice! (arbitrary chosen :P hehe)
+        layer_surface.set_exclusive_zone(-69); // nice! (arbitrary chosen :P hehe)
         layer_surface.set_anchor(Anchor::all());
         layer_surface.set_size(size.width, size.height);
         layer_surface.set_keyboard_interactivity(KeyboardInteractivity::None);


### PR DESCRIPTION
Closes https://github.com/TornaxO7/vibe/issues/28

Although I'm unsure about this one because there are two caveats:

1. Full screen shaders are putting "on top" of the desktop. Might be undesired.
2. I'm unsure if the compositor realizes that should stop the visualizer if you start something like a game since it isn't moved into the "Background-Layer" anymore.

May I ask if any KDE users can try out this branch?
For example, if you want to apply the [aurodio] component, you won't be able to see your desktop files and directories anymore.

[aurodio]: https://github.com/TornaxO7/vibe/wiki/Config#aurodio