### PR TITLE
fix(vibe): fill up screen again

### DIFF
--- a/vibe/src/output/mod.rs
+++ b/vibe/src/output/mod.rs
@@ -39,7 +39,8 @@ impl OutputCtx {
     ) -> Self {
         let size = Size::from(&info);
 
-        layer_surface.set_exclusive_zone(-69); // nice! (arbitrary chosen :P hehe)
+        // Should be "-1" otherwise: https://github.com/TornaxO7/vibe/issues/167 happens
+        layer_surface.set_exclusive_zone(-1);
         layer_surface.set_anchor(Anchor::all());
         layer_surface.set_size(size.width, size.height);
         layer_surface.set_keyboard_interactivity(KeyboardInteractivity::None);


### PR DESCRIPTION
Closes https://github.com/TornaxO7/vibe/issues/167

Funny though. It looks like as if I'm not able to set the exclusive zone to a big negative number :(