### PR TITLE
refactor(vibe-config): set the default audio channels to stereo

### DIFF
--- a/vibe/src/config.rs
+++ b/vibe/src/config.rs
@@ -1,12 +1,13 @@
-use std::io;
-
 use serde::{Deserialize, Serialize};
+use std::io;
 use vibe_audio::{
     fetcher::{SystemAudioFetcher, SystemAudioFetcherDescriptor},
     util::DeviceType,
     SampleProcessor,
 };
 use vibe_renderer::RendererDescriptor;
+
+const STEREO_AUDIO: u16 = 2;
 
 #[derive(thiserror::Error, Debug)]
 pub enum ConfigError {
@@ -103,6 +104,7 @@ impl Config {
 
         let system_audio_fetcher = SystemAudioFetcher::new(&SystemAudioFetcherDescriptor {
             device,
+            amount_channels: Some(STEREO_AUDIO),
             ..Default::default()
         })?;
 


### PR DESCRIPTION
Closes https://github.com/TornaxO7/vibe/issues/161

Is a "weaker" version of https://github.com/TornaxO7/vibe/pull/174.
I think I'll merge this first because this will more or less guarantee that there will be at least two audio channels.

