### PR TITLE
fix(renderer, bars): pass correct frequency of bar to presence shader

### DIFF
--- a/vibe-renderer/src/components/bars/shaders/fragment_presence_gradient.wgsl
+++ b/vibe-renderer/src/components/bars/shaders/fragment_presence_gradient.wgsl
@@ -11,5 +11,5 @@ struct Input {
 
 @fragment
 fn main(in: Input) -> @location(0) vec4<f32> {
-    return mix(low_presence_color, high_presence_color, clamp(0., 1., in.bar_height));
+    return mix(low_presence_color, high_presence_color, smoothstep(0., 1., in.bar_height));
 }

--- a/vibe-renderer/src/components/bars/shaders/vertex_shader.wgsl
+++ b/vibe-renderer/src/components/bars/shaders/vertex_shader.wgsl
@@ -71,7 +71,7 @@ fn inner(freq: f32, vertex_idx: u32, instance_idx: u32) -> Output {
 
     var output: Output;
     output.pos = vec4(pos, 0., 1.);
-    output.bar_height = freq * max_height;
+    output.bar_height = freq;
 
     return output;
 }


### PR DESCRIPTION
I stupidly passed the processed bar-height (including the max height). Due to this, the color for the max height won't be truly shown. This should fix it.