### PR TITLE
feat(bars): add option for y-mirroring

### DIFF
--- a/vibe-renderer/examples/demo/main.rs
+++ b/vibe-renderer/examples/demo/main.rs
@@ -118,6 +118,7 @@ impl<'a> State<'a> {
                 // },
                 placement: BarsPlacement::Bottom,
                 format: BarsFormat::BassTreble,
+                y_mirrored: true,
             })
             .map(|bars| Box::new(bars) as Box<dyn Component>),
             ComponentName::BarsFragmentCodeVariant => Bars::new(&BarsDescriptor {
@@ -144,6 +145,7 @@ impl<'a> State<'a> {
                     ),
                 }),
                 format: BarsFormat::BassTreble,
+                y_mirrored: false,
             })
             .map(|bars| Box::new(bars) as Box<dyn Component>),
             ComponentName::BarsPresenceGradientVariant => Bars::new(&BarsDescriptor {
@@ -155,13 +157,18 @@ impl<'a> State<'a> {
                     ..Default::default()
                 },
                 texture_format: surface_config.format,
-                max_height: 0.5,
+                max_height: 0.25,
                 variant: BarVariant::PresenceGradient {
                     high: TURQUOISE,
                     low: DARK_BLUE,
                 },
-                placement: BarsPlacement::Bottom,
+                placement: BarsPlacement::Custom {
+                    bottom_left_corner: (0., 0.5),
+                    width_factor: 1.0,
+                    rotation: Deg(0.),
+                },
                 format: BarsFormat::TrebleBassTreble,
+                y_mirrored: true,
             })
             .map(|bars| Box::new(bars) as Box<dyn Component>),
             ComponentName::CircleCurvedVariant => Ok(Box::new(Circle::new(&CircleDescriptor {

--- a/vibe-renderer/src/components/bars/descriptor.rs
+++ b/vibe-renderer/src/components/bars/descriptor.rs
@@ -15,6 +15,7 @@ pub struct BarsDescriptor<'a, F: Fetcher> {
 
     pub placement: BarsPlacement,
     pub format: BarsFormat,
+    pub y_mirrored: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/vibe-renderer/src/components/bars/shaders/vertex_shader.wgsl
+++ b/vibe-renderer/src/components/bars/shaders/vertex_shader.wgsl
@@ -1,24 +1,23 @@
+struct VertexParams {
+    bottom_left_corner: vec2f,
+    // Normalized
+    up_direction: vec2f,
+    // Not normalized.
+    // Length equals a full column "slot" (with the direction to the next column)
+    column_direction: vec2f,
+    // Length: The step required for the padding
+    padding: vec2f,
+    max_height: f32,
+    height_mirrored: u32,
+};
+
 @group(0) @binding(0)
-var<uniform> bottom_left_corner: vec2f;
-
-// Normalized
-@group(0) @binding(1)
-var<uniform> up_direction: vec2f;
-
-// Not normalized.
-// Length equals a full column "slot" (with the direction to the next column)
-@group(0) @binding(2)
-var<uniform> column_direction: vec2f;
-
-// Length: The step required for the padding
-@group(0) @binding(3)
-var<uniform> padding: vec2f;
-
-@group(0) @binding(4)
-var<uniform> max_height: f32;
+var<uniform> vp: VertexParams;
 
 @group(1) @binding(0)
 var<storage, read> freqs: array<f32>;
+
+const TRUE: u32 = 1;
 
 struct Input {
     @builtin(vertex_index) vertex_idx: u32,
@@ -53,20 +52,22 @@ fn treble_bass(in: Input) -> Output {
 }
 
 fn inner(freq: f32, vertex_idx: u32, instance_idx: u32) -> Output {
-    var pos: vec2f = bottom_left_corner;
+    var pos: vec2f = vp.bottom_left_corner;
 
     // x
     let is_bar_left_side = vertex_idx == 0 || vertex_idx == 2;
     if (is_bar_left_side) {
-        pos += f32(instance_idx) * column_direction + padding;
+        pos += f32(instance_idx) * vp.column_direction + vp.padding;
     } else {
-        pos += f32(instance_idx + 1) * column_direction - padding;
+        pos += f32(instance_idx + 1) * vp.column_direction - vp.padding;
     }
 
     // y
     let is_top_vertex = vertex_idx <= 1; 
     if (is_top_vertex) {
-        pos += up_direction * freq * max_height;
+        pos += vp.up_direction * freq * vp.max_height;
+    } else if (vp.height_mirrored == TRUE) {
+        pos += -vp.up_direction * freq * vp.max_height;
     }
 
     var output: Output;

--- a/vibe-renderer/tests/bar_color_variant/mod.rs
+++ b/vibe-renderer/tests/bar_color_variant/mod.rs
@@ -19,6 +19,7 @@ fn test() {
         variant: BarVariant::Color(RED),
         placement: BarsPlacement::Top,
         format: BarsFormat::BassTreble,
+        y_mirrored: true,
     })
     .unwrap_or_else(|msg| panic!("{}", msg));
 

--- a/vibe-renderer/tests/bar_fragment_code_variant/mod.rs
+++ b/vibe-renderer/tests/bar_fragment_code_variant/mod.rs
@@ -24,6 +24,7 @@ fn wgsl_passes() {
         }),
         placement: vibe_renderer::components::BarsPlacement::Left,
         format: BarsFormat::BassTrebleBass,
+        y_mirrored: true,
     })
     .unwrap_or_else(|msg| panic!("{}", msg));
 
@@ -54,6 +55,7 @@ fn glsl_passes() {
         }),
         placement: vibe_renderer::components::BarsPlacement::Left,
         format: BarsFormat::TrebleBass,
+        y_mirrored: false,
     })
     .unwrap_or_else(|msg| panic!("{}", msg));
 

--- a/vibe-renderer/tests/bar_presence_gradient_variant/mod.rs
+++ b/vibe-renderer/tests/bar_presence_gradient_variant/mod.rs
@@ -23,6 +23,7 @@ fn test() {
         },
         placement: vibe_renderer::components::BarsPlacement::Right,
         format: BarsFormat::TrebleBassTreble,
+        y_mirrored: true,
     })
     .unwrap_or_else(|msg| panic!("{}", msg));
 

--- a/vibe/src/output/config/component/mod.rs
+++ b/vibe/src/output/config/component/mod.rs
@@ -38,6 +38,7 @@ pub enum ComponentConfig {
         variant: BarsVariantConfig,
         placement: BarsPlacementConfig,
         format: BarsFormatConfig,
+        height_mirrored: bool,
     },
     FragmentCanvas {
         audio_conf: FragmentCanvasAudioConfig,
@@ -94,6 +95,7 @@ impl Default for ComponentConfig {
             variant: BarsVariantConfig::Color(Rgba::TURQUOISE),
             placement: BarsPlacementConfig::Bottom,
             format: BarsFormatConfig::BassTreble,
+            height_mirrored: false,
         }
     }
 }
@@ -112,6 +114,7 @@ impl ComponentConfig {
                 variant,
                 placement,
                 format,
+                height_mirrored,
             } => {
                 let variant = match variant {
                     BarsVariantConfig::Color(rgba) => BarVariant::Color(rgba.as_f32()),
@@ -134,6 +137,7 @@ impl ComponentConfig {
                     variant,
                     placement: BarsPlacement::from(placement),
                     format: BarsFormat::from(format),
+                    y_mirrored: *height_mirrored,
                 })
                 .map(|bars| Box::new(bars) as Box<dyn Component>)
             }

--- a/vibe/src/output/config/mod.rs
+++ b/vibe/src/output/config/mod.rs
@@ -115,6 +115,7 @@ mod tests {
                     }),
                     placement: component::BarsPlacementConfig::Bottom,
                     format: component::BarsFormatConfig::BassTreble,
+                    height_mirrored: true,
                 },
             ],
         };

--- a/vibe/src/output/config/reference-config.toml
+++ b/vibe/src/output/config/reference-config.toml
@@ -8,6 +8,7 @@ enable = true
 placement = "Bottom"
 max_height = 0.75
 format = "BassTreble"
+height_mirrored = true
 [components.Bars.audio_conf]
 amount_bars = 60
 sensitivity = 4.0
@@ -21,6 +22,7 @@ Color = [0, 255, 255, 255]
 max_height = 0.75
 placement = "Top"
 format = "TrebleBass"
+height_mirrored = false
 [components.Bars.audio_conf]
 amount_bars = 60
 sensitivity = 2.0
@@ -35,6 +37,7 @@ low_presence = [13, 0, 82, 255]
 max_height = 0.75
 placement = "Left"
 format = "TrebleBassTreble"
+height_mirrored = false
 [components.Bars.audio_conf]
 amount_bars = 60
 sensitivity = 2.0
@@ -49,6 +52,7 @@ path = "/tmp/fragment_code.wgsl"
 max_height = 0.75
 placement = "Right"
 format = "BassTrebleBass"
+height_mirrored = true
 [components.Bars.audio_conf]
 amount_bars = 60
 sensitivity = 3.0
@@ -62,6 +66,7 @@ path = "/tmp/fragment_code.wgsl"
 [components.Bars]
 max_height = 0.75
 format = "BassTreble"
+height_mirrored = true
 [components.Bars.placement.Custom]
 bottom_left_corner = [0.0, 0.0]
 width_factor = 1.0
@@ -87,6 +92,7 @@ fn main(@builtin(position) pos: vec4<f32>) -> @location(0) vec4<f32> {
 max_height = 0.75
 placement = "Bottom"
 format = "TrebleBass"
+height_mirrored = true
 [components.Bars.audio_conf]
 amount_bars = 60
 sensitivity = 0.5
@@ -101,6 +107,7 @@ path = "/tmp/fragment_code.glsl"
 max_height = 0.75
 placement = "Bottom"
 format = "TrebleBassTreble"
+height_mirrored = true
 [components.Bars.audio_conf]
 amount_bars = 60
 sensitivity = 3.0


### PR DESCRIPTION

https://github.com/user-attachments/assets/af375d07-e6d3-46c6-998b-505e3e804f7a


Adds the `height_mirrored` option to the bars component.

Song: https://www.youtube.com/watch?v=Vx-BAMobGFk&pp=ygUVc2VsZiBjb250cm9sIGluZmVybmFs0gcJCcoJAYcqIYzv