### PR TITLE
fix(bars)!: fix aspect ratio for custom placement

### DIFF
--- a/vibe-renderer/examples/demo/main.rs
+++ b/vibe-renderer/examples/demo/main.rs
@@ -162,7 +162,7 @@ impl<'a> State<'a> {
                 },
                 placement: BarsPlacement::Custom {
                     bottom_left_corner: (0., 0.5),
-                    width_factor: 0.25,
+                    width: NonZero::new(100).unwrap(),
                     rotation: Deg(0.),
                     height_mirrored: true,
                 },

--- a/vibe-renderer/src/components/bars/descriptor.rs
+++ b/vibe-renderer/src/components/bars/descriptor.rs
@@ -1,7 +1,7 @@
 use cgmath::Deg;
 use vibe_audio::{fetcher::Fetcher, SampleProcessor};
 
-use crate::components::{Rgba, ShaderCode};
+use crate::components::{Pixels, Rgba, ShaderCode};
 
 pub struct BarsDescriptor<'a, F: Fetcher> {
     pub device: &'a wgpu::Device,
@@ -24,8 +24,7 @@ pub enum BarsPlacement {
         // - (0., 0.) is the top left corner
         // - (1., 1.) is the bottom right corner
         bottom_left_corner: (f32, f32),
-        // percentage of the screen width (so it should be within the range [0, 1])
-        width_factor: f32,
+        width: Pixels<u16>,
         rotation: Deg<f32>,
         height_mirrored: bool,
     },

--- a/vibe-renderer/src/components/bars/mod.rs
+++ b/vibe-renderer/src/components/bars/mod.rs
@@ -27,8 +27,6 @@ struct VertexParams {
     bottom_left_corner: Vec2f,
     up_direction: Vec2f,
     column_direction: Vec2f,
-    // the padding between each bar
-    padding: Vec2f,
     max_height: f32,
     // should be a boolean, but... you know, it's not possible due to `bytemuck::Pod`.
     // So, it's meaning is:
@@ -142,8 +140,6 @@ impl Bars {
             desc.audio_conf.amount_bars.get(),
         );
 
-        let padding = column_direction * 0.2;
-
         // == create buffers ==
         let mut resource_manager = ResourceManager::new();
 
@@ -166,7 +162,6 @@ impl Bars {
                     bottom_left_corner: bottom_left_corner.into(),
                     up_direction: up_direction.into(),
                     column_direction: column_direction.into(),
-                    padding: padding.into(),
                     max_height: desc.max_height * VERTEX_SURFACE_WIDTH,
                     height_mirrored,
                     amount_bars: amount_bars.get() as u32,

--- a/vibe-renderer/src/components/bars/shaders/main.wgsl
+++ b/vibe-renderer/src/components/bars/shaders/main.wgsl
@@ -5,8 +5,6 @@ struct VertexParams {
     // Not normalized.
     // Length equals a full column "slot" (with the direction to the next column)
     column_direction: vec2f,
-    // Length: The step required for the padding
-    padding: vec2f,
     max_height: f32,
     height_mirrored: u32,
     amount_bars: u32,
@@ -61,13 +59,15 @@ fn inner(freq: f32, vertex_idx: u32, instance_idx: u32) -> Output {
     var output: Output;
     output.freq = freq;
 
+    let padding = vp.column_direction * .2;
+
     // x
     let is_left_channel = instance_idx < vp.amount_bars;
     let is_bar_left_side = vertex_idx == 0 || vertex_idx == 2;
 
     var pos = vp.bottom_left_corner;
     if (is_bar_left_side) {
-        pos += f32(instance_idx) * vp.column_direction + vp.padding;
+        pos += f32(instance_idx) * vp.column_direction + padding;
 
         if (is_left_channel) {
             output.rel_pos.x = f32(instance_idx) / f32(vp.amount_bars);
@@ -75,7 +75,7 @@ fn inner(freq: f32, vertex_idx: u32, instance_idx: u32) -> Output {
             output.rel_pos.x = f32(vp.amount_bars*2 - instance_idx) / f32(vp.amount_bars);
         }
     } else {
-        pos += f32(instance_idx + 1) * vp.column_direction - vp.padding;
+        pos += f32(instance_idx + 1) * vp.column_direction - padding;
 
         if (is_left_channel) {
             output.rel_pos.x = f32(instance_idx + 1) / f32(vp.amount_bars);

--- a/vibe-renderer/src/components/bars/shaders/main.wgsl
+++ b/vibe-renderer/src/components/bars/shaders/main.wgsl
@@ -34,12 +34,15 @@ struct Output {
 
 // Assuming:
 //
-// 0    1
-//  ----
-//  |\ |
-//  | \|
-//  ----
-// 2    3
+// ^ y
+// |
+// |  0    1
+// |   ----
+// |   |\ |
+// |   | \|
+// |   ----
+// |  2    3
+// ----------> x
 @vertex
 fn bass_treble(in: Input) -> Output {
     let freq_idx = in.instance_idx % arrayLength(&freqs);

--- a/vibe-renderer/src/components/mod.rs
+++ b/vibe-renderer/src/components/mod.rs
@@ -21,12 +21,14 @@ pub use value_noise::{ValueNoise, ValueNoiseDescriptor};
 
 use crate::{Renderable, Renderer};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::{num::NonZero, path::PathBuf};
 use vibe_audio::{fetcher::SystemAudioFetcher, SampleProcessor};
 
 // rgba values are each directly set in the fragment shader
 pub type Rgba = [f32; 4];
 pub type Rgb = [f32; 3];
+
+pub type Pixels<N> = NonZero<N>;
 
 /// Every component needs to implement this.
 /// It provides methods to update its internal state regarding the current

--- a/vibe/src/output/config/component/bars.rs
+++ b/vibe/src/output/config/component/bars.rs
@@ -1,7 +1,7 @@
 use std::{num::NonZero, ops::Range};
 
 use serde::{Deserialize, Serialize};
-use vibe_renderer::components::{BarsFormat, BarsPlacement, ShaderCode};
+use vibe_renderer::components::{BarsFormat, BarsPlacement, Pixels, ShaderCode};
 
 use super::Rgba;
 
@@ -66,7 +66,7 @@ pub enum BarsPlacementConfig {
     Right,
     Custom {
         bottom_left_corner: (f32, f32),
-        width_factor: f32,
+        width: Pixels<u16>,
         rotation: cgmath::Deg<f32>,
         height_mirrored: Option<bool>,
     },
@@ -81,12 +81,12 @@ impl From<BarsPlacementConfig> for BarsPlacement {
             BarsPlacementConfig::Right => BarsPlacement::Right,
             BarsPlacementConfig::Custom {
                 bottom_left_corner,
-                width_factor,
+                width,
                 rotation,
                 height_mirrored,
             } => BarsPlacement::Custom {
                 bottom_left_corner,
-                width_factor,
+                width,
                 rotation,
                 height_mirrored: height_mirrored.unwrap_or(false),
             },

--- a/vibe/src/output/config/reference-config.toml
+++ b/vibe/src/output/config/reference-config.toml
@@ -92,7 +92,7 @@ max_height = 0.75
 format = "BassTreble"
 [components.Bars.placement.Custom]
 bottom_left_corner = [0.0, 0.0]
-width_factor = 1.0
+width = 100
 rotation = 0.0
 height_mirrored = false
 [components.Bars.audio_conf]


### PR DESCRIPTION
Closes https://github.com/TornaxO7/vibe/issues/179

Includes a breaking change: You should now set the width in _pixels_ and not with a `width_factor` anymore.

Example image:

<img width="2256" height="1504" alt="image" src="https://github.com/user-attachments/assets/3c085571-99cf-4641-bcf6-1b33781b6d28" />

Used config:

<details>

```toml
[[components]]
[components.Bars]
max_height = 0.5
format = "TrebleBassTreble"
# placement = "Bottom"
[components.Bars.placement.Custom]
bottom_left_corner = [0.0, 1.0]
width = 2232
rotation = 20.0
[components.Bars.audio_conf]
amount_bars = 30
sensitivity = 4.0
freq_range = { start = 50, end = 10000 }
# [components.Bars.variant]
# Color = [0, 255, 255, 255]
# [components.Bars.variant.PresenceGradient]
# high_presence = [0, 255, 255, 255]
# low_presence = [13, 0, 82, 255]
# [components.Bars.variant.HorizontalGradient]
# left = [0, 0, 255, 255]
# right = [255, 0, 0, 255]
[components.Bars.variant.VerticalGradient]
top = [255, 0, 0, 255]
bottom = [0, 0, 255, 255]
```

</details>
