### PR TITLE
feat: add warning for first time usages

### DIFF
--- a/vibe/src/state.rs
+++ b/vibe/src/state.rs
@@ -76,6 +76,12 @@ impl State {
                 {
                     match io_err.kind() {
                         std::io::ErrorKind::NotFound => {
+                            warn!(concat![
+                                "Looks like you are starting `vibe` for the first time.\n",
+                                "\tPlease see the 5th point here: <https://github.com/TornaxO7/vibe/blob/main/USAGE.md>\n",
+                                "\tto check if `vibe` is listenting to the correct source."
+                            ]);
+
                             if let Err(err) = default_config.save() {
                                 warn!("Couldn't save default config file: {:?}", err);
                             }


### PR DESCRIPTION
The output text for first time starts will look like this (the warning output is new):

<img width="1339" height="394" alt="image" src="https://github.com/user-attachments/assets/6581eacd-383b-46c1-91d0-ca9ca59ca57a" />
