### PR TITLE
refactor: create type aliases for wgsl types

### DIFF
--- a/vibe-renderer/examples/demo/main.rs
+++ b/vibe-renderer/examples/demo/main.rs
@@ -39,6 +39,9 @@ use crate::texture_component::{TextureComponent, TextureComponentDescriptor};
 
 const TURQUOISE: [f32; 4] = [0., 1., 1., 1.];
 const DARK_BLUE: [f32; 4] = [0.05, 0., 0.321, 255.];
+const BLUE: [f32; 4] = [0., 0., 1., 1.];
+const RED: [f32; 4] = [1., 0., 0., 1.];
+const WHITE: [f32; 4] = [1f32; 4];
 
 struct State<'a> {
     renderer: Renderer,
@@ -101,7 +104,7 @@ impl<'a> State<'a> {
                         zoom_factor: 10.,
                     },
                 ],
-                base_color: [0., 0.5, 0.5],
+                base_color: [0., 0.5, 0.5].into(),
                 movement_speed: 0.005,
                 sensitivity: 0.2,
             })) as Box<dyn Component>),
@@ -115,7 +118,7 @@ impl<'a> State<'a> {
                 },
                 texture_format: surface_config.format,
                 max_height: 0.5,
-                variant: BarVariant::Color([0., 0., 1., 1.]),
+                variant: BarVariant::Color([0., 0., 1., 1.].into()),
                 // placement: BarsPlacement::Custom {
                 //     bottom_left_corner: (0.5, 0.5),
                 //     width_factor: 0.5,
@@ -136,8 +139,8 @@ impl<'a> State<'a> {
                 texture_format: surface_config.format,
                 max_height: 0.25,
                 variant: BarVariant::PresenceGradient {
-                    high: TURQUOISE,
-                    low: DARK_BLUE,
+                    high: TURQUOISE.into(),
+                    low: DARK_BLUE.into(),
                 },
                 placement: BarsPlacement::Custom {
                     bottom_left_corner: (0., 0.5),
@@ -158,7 +161,7 @@ impl<'a> State<'a> {
                 texture_format: surface_config.format,
                 variant: CircleVariant::Graph {
                     spike_sensitivity: 0.3,
-                    color: [0., 1., 1., 1.],
+                    color: TURQUOISE.into(),
                 },
 
                 radius: 0.1,
@@ -196,7 +199,7 @@ impl<'a> State<'a> {
                 sample_processor: processor,
                 audio_conf: BarProcessorConfig::default(),
                 output_texture_format: surface_config.format,
-                variant: GraphVariant::Color([0., 0., 1., 1.]),
+                variant: GraphVariant::Color(BLUE.into()),
                 max_height: 0.5,
                 format: GraphFormat::BassTreble,
                 // placement: vibe_renderer::components::GraphPlacement::Bottom,
@@ -216,8 +219,8 @@ impl<'a> State<'a> {
                     },
                     output_texture_format: surface_config.format,
                     variant: GraphVariant::HorizontalGradient {
-                        left: [1., 0., 0., 1.],
-                        right: [0., 0., 1., 1.],
+                        left: RED.into(),
+                        right: BLUE.into(),
                     },
                     max_height: 0.5,
                     format: GraphFormat::BassTreble,
@@ -235,8 +238,8 @@ impl<'a> State<'a> {
                     },
                     output_texture_format: surface_config.format,
                     variant: GraphVariant::VerticalGradient {
-                        top: [1., 0., 0., 1.],
-                        bottom: [0., 0., 1., 1.],
+                        top: RED.into(),
+                        bottom: BLUE.into(),
                     },
                     max_height: 0.5,
                     format: GraphFormat::BassTrebleBass,
@@ -257,7 +260,7 @@ impl<'a> State<'a> {
                 },
                 output_texture_format: surface_config.format,
 
-                variant: RadialVariant::Color([1., 0., 0., 1.]),
+                variant: RadialVariant::Color(RED.into()),
 
                 init_rotation: cgmath::Deg(90.),
                 circle_radius: 0.2,
@@ -279,8 +282,8 @@ impl<'a> State<'a> {
                     output_texture_format: surface_config.format,
 
                     variant: RadialVariant::HeightGradient {
-                        inner: [1., 0., 0., 1.],
-                        outer: [1., 1., 1., 1.],
+                        inner: RED.into(),
+                        outer: WHITE.into(),
                     },
 
                     init_rotation: cgmath::Deg(90.),

--- a/vibe-renderer/src/components/bars/mod.rs
+++ b/vibe-renderer/src/components/bars/mod.rs
@@ -2,11 +2,8 @@ mod descriptor;
 
 pub use descriptor::*;
 
-use super::{Component, ShaderCodeError};
-use crate::{
-    components::{Pixels, Rgba},
-    Renderable,
-};
+use super::{Component, Pixels, Rgba, ShaderCodeError, Vec2f};
+use crate::Renderable;
 use cgmath::{Deg, Matrix2, Vector2};
 use std::num::NonZero;
 use vibe_audio::{
@@ -25,19 +22,24 @@ const INIT_COLUMN_DIRECTION: Vector2<f32> = Vector2::new(1.0, 0.0);
 const TRUE: u32 = 1;
 const FALSE: u32 = 0;
 
-type Vec2f = [f32; 2];
+type ColumnDirection = Vec2f;
+type BottomLeftCorner = Vec2f;
+type UpDirection = Vec2f;
+type MaxHeight = f32;
+type HeightMirrored = u32;
+type AmountBars = u32;
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, bytemuck::Zeroable, bytemuck::Pod)]
 struct VertexParams {
-    column_direction: Vec2f,
-    bottom_left_corner: Vec2f,
-    up_direction: Vec2f,
-    max_height: f32,
+    column_direction: ColumnDirection,
+    bottom_left_corner: BottomLeftCorner,
+    up_direction: UpDirection,
+    max_height: MaxHeight,
     // should be a boolean, but... you know, it's not possible due to `bytemuck::Pod`.
     // So, it's meaning is: 1 = True, 0 = False
-    height_mirrored: u32,
-    amount_bars: u32,
+    height_mirrored: HeightMirrored,
+    amount_bars: AmountBars,
 
     // memory padding
     _padding1: u32,
@@ -151,7 +153,7 @@ impl Bars {
                 column_direction: column_direction.into(),
                 max_height: desc.max_height * VERTEX_SURFACE_WIDTH,
                 height_mirrored,
-                amount_bars: amount_bars.get() as u32,
+                amount_bars: amount_bars.get() as AmountBars,
                 _padding1: 0,
             }
         };

--- a/vibe-renderer/src/components/chessy/mod.rs
+++ b/vibe-renderer/src/components/chessy/mod.rs
@@ -2,8 +2,8 @@ mod descriptor;
 
 pub use descriptor::*;
 
+use super::{Component, Vec2f};
 use crate::{
-    components::Component,
     texture_generation::{SdfMask, SdfPattern},
     Renderable,
 };
@@ -13,13 +13,18 @@ use wgpu::{include_wgsl, util::DeviceExt};
 // this texture size seems good enough for a 1920x1080 screen.
 const DEFAULT_SDF_TEXTURE_SIZE: u32 = 512;
 
+type Resolution = Vec2f;
+type Time = f32;
+type MovementSpeed = f32;
+type ZoomFactor = f32;
+
 #[repr(C)]
 #[derive(Debug, Clone, Copy, bytemuck::Pod, bytemuck::Zeroable, Default)]
 struct Data {
-    resolution: [f32; 2],
-    time: f32,
-    movement_speed: f32,
-    zoom_factor: f32,
+    resolution: Resolution,
+    time: Time,
+    movement_speed: MovementSpeed,
+    zoom_factor: ZoomFactor,
     _padding: f32,
 }
 
@@ -45,7 +50,7 @@ impl Chessy {
         let bar_processor = BarProcessor::new(desc.sample_processor, desc.audio_config.clone());
 
         let data = Data {
-            resolution: [0f32; 2],
+            resolution: Resolution::default(),
             time: 0f32,
             movement_speed: desc.movement_speed,
             zoom_factor: desc.zoom_factor,

--- a/vibe-renderer/src/components/circle/mod.rs
+++ b/vibe-renderer/src/components/circle/mod.rs
@@ -3,21 +3,29 @@ mod descriptor;
 pub use descriptor::*;
 use vibe_audio::fetcher::{Fetcher, SystemAudioFetcher};
 
-use super::Component;
+use super::{Component, Mat2x2, Rgba, Vec2f};
 use crate::{util::SimpleRenderPipelineDescriptor, Renderable};
 use cgmath::Matrix2;
 use wgpu::{include_wgsl, util::DeviceExt};
 
+type Resolution = Vec2f;
+type PositionOffset = Vec2f;
+type Color = Rgba;
+type Rotation = Mat2x2;
+type Radius = f32;
+type SpikeSensitivity = f32;
+type FreqRadiantStep = f32;
+
 #[repr(C)]
 #[derive(Debug, Clone, Copy, bytemuck::Zeroable, bytemuck::Pod, Default)]
 struct Data {
-    resolution: [f32; 2],
-    position_offset: [f32; 2],
-    color: super::Rgba,
-    rotation: [[f32; 2]; 2],
-    radius: f32,
-    spike_sensitivity: f32,
-    freq_radiant_step: f32,
+    resolution: Resolution,
+    position_offset: PositionOffset,
+    color: Color,
+    rotation: Rotation,
+    radius: Radius,
+    spike_sensitivity: SpikeSensitivity,
+    freq_radiant_step: FreqRadiantStep,
     _padding: f32,
 }
 
@@ -50,7 +58,7 @@ impl Circle {
                 let rel_x_offset = desc.position.0.clamp(0., 1.);
                 let rel_y_offset = desc.position.1.clamp(0., 1.);
 
-                [rel_x_offset, rel_y_offset]
+                PositionOffset::from([rel_x_offset, rel_y_offset])
             };
 
             Data {
@@ -58,7 +66,7 @@ impl Circle {
                 spike_sensitivity,
                 freq_radiant_step: std::f32::consts::PI
                     / (u16::from(desc.audio_conf.amount_bars) as f32 + 0.99),
-                resolution: [0f32; 2],
+                resolution: Resolution::default(),
                 position_offset,
                 color,
                 rotation: Matrix2::from_angle(desc.rotation).into(),

--- a/vibe-renderer/src/components/graph/mod.rs
+++ b/vibe-renderer/src/components/graph/mod.rs
@@ -2,7 +2,7 @@ mod descriptor;
 
 pub use descriptor::*;
 
-use super::Component;
+use super::{Component, Rgba, Vec2f};
 use crate::{Renderable, Renderer};
 use cgmath::{Deg, Matrix2, Vector2};
 use std::num::NonZero;
@@ -57,19 +57,23 @@ struct PipelineCtx {
     freqs_buffer: wgpu::Buffer,
 }
 
+type Right = Vec2f;
+type BottomLeftCorner = Vec2f;
+type Up = Vec2f;
+
 #[repr(C)]
 #[derive(Debug, Clone, Copy, bytemuck::Zeroable, bytemuck::Pod, Default)]
 struct VertexParams {
-    right: [f32; 2],
-    bottom_left_corner: [f32; 2],
-    up: [f32; 2],
+    right: Right,
+    bottom_left_corner: BottomLeftCorner,
+    up: Up,
 }
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, bytemuck::Zeroable, bytemuck::Pod, Default)]
 struct FragmentParams {
-    color1: [f32; 4],
-    color2: [f32; 4],
+    color1: Rgba,
+    color2: Rgba,
 }
 
 pub struct Graph {
@@ -148,9 +152,9 @@ impl Graph {
             };
 
             let vertex_params = VertexParams {
-                bottom_left_corner: Into::<[f32; 2]>::into(bottom_left_corner),
-                right: Into::<[f32; 2]>::into(right),
-                up: Into::<[f32; 2]>::into(up),
+                bottom_left_corner: bottom_left_corner.into(),
+                right: right.into(),
+                up: up.into(),
             };
 
             device.create_buffer_init(&wgpu::util::BufferInitDescriptor {

--- a/vibe-renderer/src/components/mod.rs
+++ b/vibe-renderer/src/components/mod.rs
@@ -21,12 +21,12 @@ pub use radial::{Radial, RadialDescriptor, RadialFormat, RadialVariant};
 use crate::{Renderable, Renderer};
 use serde::{Deserialize, Serialize};
 use std::{num::NonZero, path::PathBuf};
+use utils::wgsl_types::*;
 use vibe_audio::{fetcher::SystemAudioFetcher, SampleProcessor};
 
 // rgba values are each directly set in the fragment shader
-pub type Rgba = [f32; 4];
-pub type Rgb = [f32; 3];
-
+pub type Rgba = Vec4f;
+pub type Rgb = Vec3f;
 pub type Pixels<N> = NonZero<N>;
 
 /// Every component needs to implement this.

--- a/vibe-renderer/src/components/utils/mod.rs
+++ b/vibe-renderer/src/components/utils/mod.rs
@@ -1,1 +1,1 @@
-
+pub mod wgsl_types;

--- a/vibe-renderer/src/components/utils/wgsl_types.rs
+++ b/vibe-renderer/src/components/utils/wgsl_types.rs
@@ -1,0 +1,65 @@
+//! Type wrappers of types which are used in the wgsl language.
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, bytemuck::Zeroable, bytemuck::Pod, Default)]
+pub struct Vec2f([f32; 2]);
+
+impl From<[f32; 2]> for Vec2f {
+    fn from(value: [f32; 2]) -> Self {
+        Self(value)
+    }
+}
+
+impl From<cgmath::Vector2<f32>> for Vec2f {
+    fn from(value: cgmath::Vector2<f32>) -> Self {
+        Self(value.into())
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, bytemuck::Zeroable, bytemuck::Pod, Default)]
+pub struct Vec3f([f32; 3]);
+
+impl From<[f32; 3]> for Vec3f {
+    fn from(value: [f32; 3]) -> Self {
+        Self(value)
+    }
+}
+
+impl From<cgmath::Vector3<f32>> for Vec3f {
+    fn from(value: cgmath::Vector3<f32>) -> Self {
+        Self(value.into())
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, bytemuck::Zeroable, bytemuck::Pod, Default)]
+pub struct Vec4f([f32; 4]);
+
+impl From<[f32; 4]> for Vec4f {
+    fn from(value: [f32; 4]) -> Self {
+        Self(value)
+    }
+}
+
+impl From<cgmath::Vector4<f32>> for Vec4f {
+    fn from(value: cgmath::Vector4<f32>) -> Self {
+        Self(value.into())
+    }
+}
+
+#[repr(C)]
+#[derive(Debug, Clone, Copy, bytemuck::Zeroable, bytemuck::Pod, Default)]
+pub struct Mat2x2([[f32; 2]; 2]);
+
+impl From<[[f32; 2]; 2]> for Mat2x2 {
+    fn from(value: [[f32; 2]; 2]) -> Self {
+        Self(value)
+    }
+}
+
+impl From<cgmath::Matrix2<f32>> for Mat2x2 {
+    fn from(value: cgmath::Matrix2<f32>) -> Self {
+        Self(value.into())
+    }
+}

--- a/vibe-renderer/tests/aurodio/mod.rs
+++ b/vibe-renderer/tests/aurodio/mod.rs
@@ -16,7 +16,7 @@ fn test() {
         renderer: &tester.renderer,
         sample_processor: &sample_processor,
         texture_format: tester.output_texture_format(),
-        base_color: BLUE,
+        base_color: BLUE.into(),
         movement_speed: 0.2,
         layers: &[AurodioLayerDescriptor {
             freq_range: NonZero::new(50).unwrap()..NonZero::new(200).unwrap(),

--- a/vibe-renderer/tests/bar_color_variant/mod.rs
+++ b/vibe-renderer/tests/bar_color_variant/mod.rs
@@ -1,9 +1,7 @@
 use vibe_audio::{fetcher::DummyFetcher, BarProcessorConfig, SampleProcessor};
 use vibe_renderer::components::{BarVariant, Bars, BarsDescriptor, BarsFormat, BarsPlacement};
 
-use crate::Tester;
-
-const RED: [f32; 4] = [1., 0., 0., 1.];
+use crate::{Tester, RED};
 
 #[test]
 fn test() {
@@ -16,7 +14,7 @@ fn test() {
         audio_conf: BarProcessorConfig::default(),
         texture_format: tester.output_texture_format(),
         max_height: 1.,
-        variant: BarVariant::Color(RED),
+        variant: BarVariant::Color(RED.into()),
         placement: BarsPlacement::Top,
         format: BarsFormat::BassTreble,
     })

--- a/vibe-renderer/tests/bar_presence_gradient_variant/mod.rs
+++ b/vibe-renderer/tests/bar_presence_gradient_variant/mod.rs
@@ -1,10 +1,7 @@
 use vibe_audio::{fetcher::DummyFetcher, BarProcessorConfig, SampleProcessor};
 use vibe_renderer::components::{BarVariant, Bars, BarsDescriptor, BarsFormat};
 
-use crate::Tester;
-
-const RED: [f32; 4] = [1., 0., 0., 1.];
-const BLUE: [f32; 4] = [0., 0., 1., 1.];
+use crate::{Tester, BLUE, RED};
 
 #[test]
 fn test() {
@@ -18,8 +15,8 @@ fn test() {
         texture_format: tester.output_texture_format(),
         max_height: 1.,
         variant: BarVariant::PresenceGradient {
-            high: RED,
-            low: BLUE,
+            high: RED.into(),
+            low: BLUE.into(),
         },
         placement: vibe_renderer::components::BarsPlacement::Right,
         format: BarsFormat::TrebleBassTreble,

--- a/vibe-renderer/tests/circle_graph/mod.rs
+++ b/vibe-renderer/tests/circle_graph/mod.rs
@@ -1,9 +1,7 @@
 use vibe_audio::{fetcher::DummyFetcher, BarProcessorConfig, SampleProcessor};
 use vibe_renderer::components::{Circle, CircleDescriptor, CircleVariant};
 
-use crate::Tester;
-
-const WHITE: [f32; 4] = [1.; 4];
+use crate::{Tester, WHITE};
 
 #[test]
 fn test() {
@@ -17,7 +15,7 @@ fn test() {
         texture_format: tester.output_texture_format(),
         variant: CircleVariant::Graph {
             spike_sensitivity: 0.1,
-            color: WHITE,
+            color: WHITE.into(),
         },
         radius: 0.1,
         rotation: cgmath::Deg(90.),

--- a/vibe-renderer/tests/graph_color_variant/mod.rs
+++ b/vibe-renderer/tests/graph_color_variant/mod.rs
@@ -14,7 +14,7 @@ fn test() {
         audio_conf: BarProcessorConfig::default(),
         output_texture_format: tester.output_texture_format(),
         max_height: 1.,
-        variant: GraphVariant::Color(RED),
+        variant: GraphVariant::Color(RED.into()),
         placement: vibe_renderer::components::GraphPlacement::Bottom,
         format: GraphFormat::BassTreble,
     });

--- a/vibe-renderer/tests/graph_horizontal_gradient_variant/mod.rs
+++ b/vibe-renderer/tests/graph_horizontal_gradient_variant/mod.rs
@@ -3,10 +3,7 @@ use std::num::NonZero;
 use vibe_audio::{fetcher::DummyFetcher, BarProcessorConfig, SampleProcessor};
 use vibe_renderer::components::{Graph, GraphDescriptor, GraphVariant};
 
-use crate::Tester;
-
-const RED: [f32; 4] = [1., 0., 0., 1.];
-const BLUE: [f32; 4] = [0., 0., 1., 1.];
+use crate::{Tester, BLUE, RED};
 
 #[test]
 fn test() {
@@ -20,8 +17,8 @@ fn test() {
         output_texture_format: tester.output_texture_format(),
         max_height: 1.,
         variant: GraphVariant::HorizontalGradient {
-            left: RED,
-            right: BLUE,
+            left: RED.into(),
+            right: BLUE.into(),
         },
         placement: vibe_renderer::components::GraphPlacement::Custom {
             bottom_left_corner: [0.2, 0.5],

--- a/vibe-renderer/tests/graph_vertical_gradient_variant/mod.rs
+++ b/vibe-renderer/tests/graph_vertical_gradient_variant/mod.rs
@@ -1,7 +1,7 @@
 use vibe_audio::{fetcher::DummyFetcher, BarProcessorConfig, SampleProcessor};
 use vibe_renderer::components::{Graph, GraphDescriptor, GraphVariant};
 
-use crate::Tester;
+use crate::{Tester, BLUE, RED};
 
 #[test]
 fn test() {
@@ -15,8 +15,8 @@ fn test() {
         output_texture_format: tester.output_texture_format(),
         max_height: 1.,
         variant: GraphVariant::VerticalGradient {
-            top: super::BLUE,
-            bottom: super::RED,
+            top: BLUE.into(),
+            bottom: RED.into(),
         },
         placement: vibe_renderer::components::GraphPlacement::Top,
         format: vibe_renderer::components::GraphFormat::TrebleBassTreble,

--- a/vibe-renderer/tests/radial_color_variant/mod.rs
+++ b/vibe-renderer/tests/radial_color_variant/mod.rs
@@ -1,7 +1,7 @@
 use vibe_audio::{fetcher::DummyFetcher, BarProcessorConfig, SampleProcessor};
 use vibe_renderer::components::{Radial, RadialDescriptor, RadialVariant};
 
-use crate::Tester;
+use crate::{Tester, RED};
 
 #[test]
 fn test() {
@@ -13,7 +13,7 @@ fn test() {
         processor: &sample_processor,
         audio_conf: BarProcessorConfig::default(),
         output_texture_format: tester.output_texture_format(),
-        variant: RadialVariant::Color(super::RED),
+        variant: RadialVariant::Color(RED.into()),
 
         init_rotation: cgmath::Deg(90.0),
         circle_radius: 0.01,

--- a/vibe-renderer/tests/radial_height_gradient_variant/mod.rs
+++ b/vibe-renderer/tests/radial_height_gradient_variant/mod.rs
@@ -1,7 +1,7 @@
 use vibe_audio::{fetcher::DummyFetcher, BarProcessorConfig, SampleProcessor};
 use vibe_renderer::components::{Radial, RadialDescriptor, RadialVariant};
 
-use crate::Tester;
+use crate::{Tester, RED, WHITE};
 
 #[test]
 fn test() {
@@ -14,8 +14,8 @@ fn test() {
         audio_conf: BarProcessorConfig::default(),
         output_texture_format: tester.output_texture_format(),
         variant: RadialVariant::HeightGradient {
-            inner: super::RED,
-            outer: super::WHITE,
+            inner: RED.into(),
+            outer: WHITE.into(),
         },
 
         init_rotation: cgmath::Deg(90.0),

--- a/vibe/src/output/config/component/mod.rs
+++ b/vibe/src/output/config/component/mod.rs
@@ -272,7 +272,7 @@ impl ComponentConfig {
                     renderer,
                     sample_processor: processor,
                     texture_format,
-                    base_color: base_color.as_f32(),
+                    base_color: base_color.as_f32().into(),
                     movement_speed: *movement_speed,
                     sensitivity: audio_conf.sensitivity,
                     layers: &layers,
@@ -462,7 +462,7 @@ pub struct Rgba(pub [u8; 4]);
 impl Rgba {
     pub const TURQUOISE: Self = Self([0, 255, 255, 255]);
 
-    pub fn as_f32(&self) -> [f32; 4] {
+    pub fn as_f32(&self) -> vibe_renderer::components::Rgba {
         let mut rgba_f32 = [0f32; 4];
         for (idx, value) in self.0.iter().enumerate() {
             rgba_f32[idx] = (*value as f32) / 255f32;
@@ -473,7 +473,7 @@ impl Rgba {
             *value = value.powf(GAMMA);
         }
 
-        rgba_f32
+        rgba_f32.into()
     }
 }
 


### PR DESCRIPTION
This should especially improve the readability for offset computations for `queue.write_buffer` since you can explicitely add the types:

  std::mem::type_of::<Vec2f>()

for example