### PR TITLE
introduce non-zero threshold for detecting silence

### DIFF
--- a/vibe-audio/src/bar_processor/channel_ctx/mod.rs
+++ b/vibe-audio/src/bar_processor/channel_ctx/mod.rs
@@ -13,6 +13,7 @@ use std::ops::Range;
 
 const INIT_NORMALIZATION_FACTOR: f32 = 1.;
 const DEFAULT_PADDING_SIZE: usize = 5;
+const MIN_MAGNITUDE: f32 = 1e-16;
 
 /// Contains every additional information for a channel to be processed.
 pub struct ChannelCtx<I: Interpolater> {
@@ -135,7 +136,7 @@ impl<I: Interpolater> ChannelCtx<I> {
                     .iter()
                     .map(|out| {
                         let mag = out.norm();
-                        if mag > 0. {
+                        if mag > MIN_MAGNITUDE {
                             is_silent = false;
                         }
                         mag


### PR DESCRIPTION
Somehow the bug appeared that when you didn't play any audio, `vibe` is still registering audio which increases the normalization factor. This fixes the issue.