### PR TITLE
Refactor output config struct

### DIFF
--- a/vibe/src/output/config/mod.rs
+++ b/vibe/src/output/config/mod.rs
@@ -4,7 +4,11 @@ use crate::output::config::component::ComponentConfig;
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use smithay_client_toolkit::output::OutputInfo;
-use std::{ffi::OsStr, io, path::PathBuf};
+use std::{
+    ffi::OsStr,
+    io,
+    path::{Path, PathBuf},
+};
 
 /// Represents the config file of an output.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -21,7 +25,7 @@ pub struct OutputConfig {
 }
 
 impl OutputConfig {
-    pub fn new(info: &OutputInfo, default_component: component::Config) -> anyhow::Result<Self> {
+    pub fn new(info: &OutputInfo, default_component: component::Config) -> io::Result<Self> {
         let name = info.name.as_ref().unwrap();
 
         let new = Self {
@@ -63,6 +67,24 @@ impl OutputConfig {
     }
 }
 
+#[derive(thiserror::Error, Debug)]
+pub enum OutputConfigReadError {
+    #[error(transparent)]
+    IO(#[from] io::Error),
+
+    #[error(transparent)]
+    TomlSerde(#[from] toml::de::Error),
+}
+
+impl TryFrom<&Path> for OutputConfig {
+    type Error = OutputConfigReadError;
+
+    fn try_from(path: &Path) -> Result<Self, Self::Error> {
+        let content = std::fs::read_to_string(path).map_err(OutputConfigReadError::IO)?;
+        toml::from_str(&content).map_err(OutputConfigReadError::TomlSerde)
+    }
+}
+
 pub fn load<S: AsRef<str>>(output_name: S) -> Option<(PathBuf, anyhow::Result<OutputConfig>)> {
     let iterator = std::fs::read_dir(crate::get_output_config_dir()).unwrap();
 
@@ -71,8 +93,10 @@ pub fn load<S: AsRef<str>>(output_name: S) -> Option<(PathBuf, anyhow::Result<Ou
         let path = entry.path();
 
         if path.file_stem().unwrap() == OsStr::new(output_name.as_ref()) {
-            let content = std::fs::read_to_string(&path).unwrap();
-            return Some((path, toml::from_str(&content).context("")));
+            return Some((
+                path.clone(),
+                OutputConfig::try_from(path.as_path()).context(""),
+            ));
         }
     }
 

--- a/vibe/src/output/config/mod.rs
+++ b/vibe/src/output/config/mod.rs
@@ -38,6 +38,28 @@ impl OutputConfig {
         Ok(new)
     }
 
+    /// Tries to load the config of the given output name.
+    ///
+    /// # Returns
+    /// The absolute path to the config file of the given output name (if it exists)
+    /// and the deserialized config (if the config is correct).
+    pub fn try_load_from_name<S: AsRef<str>>(
+        output_name: S,
+    ) -> Option<(PathBuf, anyhow::Result<Self>)> {
+        let iterator = std::fs::read_dir(crate::get_output_config_dir()).unwrap();
+
+        for entry in iterator {
+            let entry = entry.unwrap();
+            let path = entry.path();
+
+            if path.file_stem().unwrap() == OsStr::new(output_name.as_ref()) {
+                return Some((path.clone(), Self::try_from(path.as_path()).context("")));
+            }
+        }
+
+        None
+    }
+
     /// Saves the current state of the config to the config file of the output.
     pub fn save(&self, name: impl AsRef<str>) -> io::Result<()> {
         let string = toml::to_string(self).unwrap();
@@ -83,24 +105,6 @@ impl TryFrom<&Path> for OutputConfig {
         let content = std::fs::read_to_string(path).map_err(OutputConfigReadError::IO)?;
         toml::from_str(&content).map_err(OutputConfigReadError::TomlSerde)
     }
-}
-
-pub fn load<S: AsRef<str>>(output_name: S) -> Option<(PathBuf, anyhow::Result<OutputConfig>)> {
-    let iterator = std::fs::read_dir(crate::get_output_config_dir()).unwrap();
-
-    for entry in iterator {
-        let entry = entry.unwrap();
-        let path = entry.path();
-
-        if path.file_stem().unwrap() == OsStr::new(output_name.as_ref()) {
-            return Some((
-                path.clone(),
-                OutputConfig::try_from(path.as_path()).context(""),
-            ));
-        }
-    }
-
-    None
 }
 
 #[cfg(test)]

--- a/vibe/src/state.rs
+++ b/vibe/src/state.rs
@@ -208,7 +208,7 @@ impl OutputHandler for State {
 
         info!("Detected output: '{}'", &name);
 
-        let config = match crate::output::config::load(&name) {
+        let config = match crate::output::config::OutputConfig::try_load_from_name(&name) {
             Some((path, res)) => match res {
                 Ok(config) => {
                     info!("Reusing '{}'.", path.to_string_lossy());

--- a/vibe/src/window.rs
+++ b/vibe/src/window.rs
@@ -143,7 +143,9 @@ impl OutputRenderer<'_> {
         let processor = config.sample_processor()?;
 
         let (output_config_path, output_config) = {
-            let Some((path, config)) = crate::output::config::load(&output_name) else {
+            let Some((path, config)) =
+                crate::output::config::OutputConfig::try_load_from_name(&output_name)
+            else {
                 bail!(
                     "The config file for '{}' does not exist. Can't start hot reloading.`",
                     output_name
@@ -211,7 +213,9 @@ impl OutputRenderer<'_> {
     // Returns `Err` if something un-saveable happened. => Signal for exiting
     pub fn refresh_config(&mut self) -> anyhow::Result<()> {
         self.output_config = {
-            let Some((path, output_config)) = crate::output::config::load(&self.output_name) else {
+            let Some((path, output_config)) =
+                crate::output::config::OutputConfig::try_load_from_name(&self.output_name)
+            else {
                 bail!(
                     "The config file of your output '{}' got removed. `vibe` will stop rendering...",
                     self.output_name


### PR DESCRIPTION
Needs to be done for https://github.com/TornaxO7/vibe/pull/294.

Reason: For `wasm` we want the config to be loadable by a string or path.